### PR TITLE
[fix] throw out wrapped error object for better error handle

### DIFF
--- a/client/common_test.go
+++ b/client/common_test.go
@@ -15,7 +15,8 @@ func TestClientChartAPI(t *testing.T) {
 	)
 	assert.Nil(t, err)
 
-	chart := myClient.Chart("2330", false)
+	chart, err := myClient.Chart("2330", false)
+	assert.Empty(t, err)
 	assert.NotNil(t, chart.Data.Chart)
 }
 
@@ -26,7 +27,8 @@ func TestClientQuoteAPI(t *testing.T) {
 	)
 	assert.Nil(t, err)
 
-	result := myClient.Quote("2330", false)
+	result, err := myClient.Quote("2330", false)
+	assert.Empty(t, err)
 	assert.NotNil(t, result.Data.Quote.Order.Bestasks)
 	assert.NotNil(t, result.Data.Quote.Order.Bestbids)
 }
@@ -38,7 +40,8 @@ func TestClientMetaAPI(t *testing.T) {
 	)
 	assert.Nil(t, err)
 
-	result := myClient.Meta("2330", false)
+	result, err := myClient.Meta("2330", false)
+	assert.Empty(t, err)
 	assert.NotEmpty(t, result.Data.Meta.Namezhtw)
 	assert.NotEmpty(t, result.Data.Meta.Industryzhtw)
 	assert.NotEmpty(t, result.Data.Meta.Volumeperunit)
@@ -54,6 +57,7 @@ func TestClientDealtsAPI(t *testing.T) {
 	)
 	assert.Nil(t, err)
 
-	result := myClient.Dealts("2330", false)
+	result, err := myClient.Dealts("2330", false)
+	assert.Empty(t, err)
 	assert.NotEmpty(t, result.Data.Dealts)
 }

--- a/client/schema.go
+++ b/client/schema.go
@@ -9,7 +9,8 @@ import (
 )
 
 type FugleAPIResponse struct {
-	APIVersion string       `json:"apiVersion"`
+	APIVersion string       `json:"api_version"`
+	StatusCode int          `json:"status_code"`
 	Data       FugleAPIData `json:"data"`
 }
 

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.16
 require (
 	github.com/joho/godotenv v1.3.0
 	github.com/kr/pretty v0.1.0 // indirect
+	github.com/pkg/errors v0.9.1
 	github.com/shopspring/decimal v1.2.0
 	github.com/sirupsen/logrus v1.8.1
 	github.com/stretchr/testify v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -9,6 +9,8 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/shopspring/decimal v1.2.0 h1:abSATXmQEYyShuxI4/vyW3tV1MrKAJzCZ/0zLUXYbsQ=

--- a/main.go
+++ b/main.go
@@ -11,8 +11,11 @@ func main() {
 		client.ConfigOption(config.Config),
 	)
 	if err != nil {
-		logrus.Fatal("failed to init fugle api client")
+		logrus.Fatal(err.Error())
 	}
-	result := myClient.Meta("0056", false)
+	result, err := myClient.Meta("0056", false)
+	if err != nil {
+		logrus.Warn(err.Error())
+	}
 	result.PrettyPrint()
 }

--- a/main.go
+++ b/main.go
@@ -1,9 +1,10 @@
 package main
 
 import (
+	"fmt"
+
 	"github.com/RainrainWu/fugle-realtime-go/client"
 	"github.com/RainrainWu/fugle-realtime-go/config"
-	"github.com/sirupsen/logrus"
 )
 
 func main() {
@@ -11,11 +12,12 @@ func main() {
 		client.ConfigOption(config.Config),
 	)
 	if err != nil {
-		logrus.Fatal(err.Error())
+		fmt.Printf("%+v\n", err)
 	}
 	result, err := myClient.Meta("0056", false)
 	if err != nil {
-		logrus.Warn(err.Error())
+		fmt.Printf("%+v\n", err)
+	} else {
+		result.PrettyPrint()
 	}
-	result.PrettyPrint()
 }


### PR DESCRIPTION
# Content
- throw out wrapped error object for better error handle.

# Related Issues
- #13 回傳結果偵錯